### PR TITLE
Concurrency tests

### DIFF
--- a/src/main/scala/nl/vroste/zio/amqp/Client.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/Client.scala
@@ -73,6 +73,13 @@ class Channel private[amqp] (channel: RChannel, access: Semaphore) {
     _.exchangeDeclare(exchange, ExchangeType.toRabbitMqType(`type`), durable, autoDelete, internal, arguments.asJava)
   ).unit
 
+  def exchangeDelete(
+    queue: String = "",
+    ifUnused: Boolean = false
+  ): ZIO[Blocking, Throwable, Unit] = withChannelBlocking(
+    _.exchangeDelete(queue, ifUnused)
+  ).unit
+
   def queueBind(
     queue: String,
     exchange: String,

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -83,7 +83,7 @@ object AmqpClientSpec extends DefaultRunnableSpec {
               bodies <- channel
                           .consume(queue = queueName, consumerTag = "test")
                           .mapM { record =>
-                            println(s"consuming record ${new String(record.getBody)}")
+//                            println(s"consuming record ${new String(record.getBody)}")
                             ZIO.succeed(record)
                           }
                           .take(numMessages.toLong)

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -67,7 +67,6 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         val uri            = URI.create(Option(System.getenv("AMQP_SERVER_URI")).getOrElse("amqp://guest:guest@localhost:5672"))
         println(uri)
         factory.setUri(uri)
-        var i              = 1
 
         (Amqp
           .connect(factory)

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -52,7 +52,51 @@ object AmqpClientSpec extends DefaultRunnableSpec {
 
                           }
                           .map(_.map(r => new String(r.getBody)))
+              _      <- channel.queueDelete(queueName)
+              _      <- channel.exchangeDelete(exchangeName)
             } yield assert(messages)(equalTo(bodies.toSet))
+          }
+      } @@ timeout(Duration(10, TimeUnit.SECONDS)),
+      testM("Amqp.consume delivers messages with high concurrency") {
+        val testAmqpSuffix = s"AmqpClientSpec-${UUID.randomUUID().toString}"
+        val exchangeName   = s"exchange-$testAmqpSuffix"
+        val queueName      = s"queue-$testAmqpSuffix"
+        val numMessages    = 10000
+        val messages       = (1 to numMessages).map(i => s"$i " + UUID.randomUUID.toString)
+        val factory        = new ConnectionFactory()
+        val uri            = URI.create(Option(System.getenv("AMQP_SERVER_URI")).getOrElse("amqp://guest:guest@localhost:5672"))
+        println(uri)
+        factory.setUri(uri)
+        var i = 1
+
+        (Amqp
+          .connect(factory)
+          .tapM(_ => ZIO(println("Connected!"))) >>= Amqp.createChannel)
+          .tapM(_ => ZIO(println("Created channel!")))
+          .use { channel =>
+            for {
+              _      <- channel.queueDeclare(queueName)
+              _      <- channel.exchangeDeclare(exchangeName, ExchangeType.Fanout)
+              _      <- channel.queueBind(queueName, exchangeName, "myroutingkey")
+              _      <-
+                ZIO.collectAllPar((0 until numMessages).map(i => channel.publish(exchangeName, messages(i).getBytes)))
+              bodies <- channel
+                          .consume(queue = queueName, consumerTag = "test")
+                          .mapM { record =>
+                            println(s"consuming record ${new String(record.getBody)}")
+                            ZIO.succeed(record)
+                          }
+                          .take(numMessages.toLong)
+                          .runCollect
+                          .tap { records =>
+                            val tag = records.last.getEnvelope.getDeliveryTag
+                            channel.ack(tag)
+
+                          }
+                          .map(_.map(r => new String(r.getBody)))
+              _      <- channel.queueDelete(queueName)
+              _      <- channel.exchangeDelete(exchangeName)
+            } yield assert(messages.toSet)(equalTo(bodies.toSet))
           }
       } @@ timeout(Duration(10, TimeUnit.SECONDS))
     )

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -67,7 +67,7 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         val uri            = URI.create(Option(System.getenv("AMQP_SERVER_URI")).getOrElse("amqp://guest:guest@localhost:5672"))
         println(uri)
         factory.setUri(uri)
-        var i = 1
+        var i              = 1
 
         (Amqp
           .connect(factory)


### PR DESCRIPTION
Attempts to test thread-safety for publishing/consuming. If you uncomment the println, you'll see 10k printlns, and while most are in order, some are out of order. For instance
```
consuming record 8414 f4878b0f-33ea-4a50-9f55-38eb02cc320c
consuming record 8415 4254f9fb-0685-4634-a569-37e3bde782d3
consuming record 8417 bb7302e9-3e19-4e0d-8a34-f1d8ff498431
consuming record 8418 0ded02d2-5d5a-4d9a-bc44-741694d2f13b
consuming record 8416 a49eb320-16e6-41f9-8f9c-aacc63038b51
consuming record 8411 c300350d-2c83-46de-b500-e3a4724e21b9
```
The `ZIO.collectAllPar` is the key to this test, which runs all the publishing to the channel in parallel -- or as much as my machine can do.