### PR TITLE
Exchange declare with custom type

### DIFF
--- a/src/main/scala/nl/vroste/zio/amqp/Client.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/Client.scala
@@ -100,6 +100,26 @@ class Channel private[amqp] (channel: RChannel, access: Semaphore) {
     )
   ).unit
 
+  // would like to overload [[exchangeDeclare]], but it's a known limitation to scala to not allow overloading methods with default params
+  // https://stackoverflow.com/questions/4652095/why-does-the-scala-compiler-disallow-overloaded-methods-with-default-arguments
+  def exchangeDeclare0(
+    exchange: ExchangeName,
+    `type`: String,
+    durable: Boolean = false,
+    autoDelete: Boolean = false,
+    internal: Boolean = false,
+    arguments: Map[String, AnyRef] = Map.empty
+  ): ZIO[Any, Throwable, Unit] = withChannelBlocking(
+    _.exchangeDeclare(
+      ExchangeName.unwrap(exchange),
+      `type`,
+      durable,
+      autoDelete,
+      internal,
+      arguments.asJava
+    )
+  ).unit
+
   def exchangeDelete(
     exchange: ExchangeName,
     ifUnused: Boolean = false

--- a/src/main/scala/nl/vroste/zio/amqp/Client.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/Client.scala
@@ -100,26 +100,6 @@ class Channel private[amqp] (channel: RChannel, access: Semaphore) {
     )
   ).unit
 
-  // would like to overload [[exchangeDeclare]], but it's a known limitation to scala to not allow overloading methods with default params
-  // https://stackoverflow.com/questions/4652095/why-does-the-scala-compiler-disallow-overloaded-methods-with-default-arguments
-  def exchangeDeclare0(
-    exchange: ExchangeName,
-    `type`: String,
-    durable: Boolean = false,
-    autoDelete: Boolean = false,
-    internal: Boolean = false,
-    arguments: Map[String, AnyRef] = Map.empty
-  ): ZIO[Any, Throwable, Unit] = withChannelBlocking(
-    _.exchangeDeclare(
-      ExchangeName.unwrap(exchange),
-      `type`,
-      durable,
-      autoDelete,
-      internal,
-      arguments.asJava
-    )
-  ).unit
-
   def exchangeDelete(
     exchange: ExchangeName,
     ifUnused: Boolean = false

--- a/src/main/scala/nl/vroste/zio/amqp/model/ExchangeType.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/model/ExchangeType.scala
@@ -5,16 +5,16 @@ sealed trait ExchangeType extends Product with Serializable {
 }
 
 object ExchangeType {
-  case object Direct  extends ExchangeType {
+  case object Direct                extends ExchangeType {
     override val name: String = "direct"
   }
-  case object Fanout  extends ExchangeType {
+  case object Fanout                extends ExchangeType {
     override val name: String = "fanout"
   }
-  case object Topic   extends ExchangeType {
+  case object Topic                 extends ExchangeType {
     override val name: String = "topic"
   }
-  case object Headers extends ExchangeType {
+  case object Headers               extends ExchangeType {
     override val name: String = "headers"
   }
   case class Custom(`type`: String) extends ExchangeType {

--- a/src/main/scala/nl/vroste/zio/amqp/model/ExchangeType.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/model/ExchangeType.scala
@@ -17,6 +17,9 @@ object ExchangeType {
   case object Headers extends ExchangeType {
     override val name: String = "headers"
   }
+  case class Custom(`type`: String) extends ExchangeType {
+    override val name: String = `type`
+  }
 
   implicit def represent(`type`: ExchangeType): String = `type`.name
 }

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -76,7 +76,7 @@ object AmqpClientSpec extends DefaultRunnableSpec {
           .use { channel =>
             for {
               _      <- channel.queueDeclare(queueName)
-              _      <- channel.exchangeDeclare0(exchangeName, "fanout")
+              _      <- channel.exchangeDeclare(exchangeName, ExchangeType.Custom("fanout")) // doesn't actually need to be a custom exchange type, just testing to make sure custom exchange types "work"
               _      <- channel.queueBind(queueName, exchangeName, RoutingKey("myroutingkey"))
               _      <-
                 ZIO.foreachParDiscard(0 until numMessages)(i => channel.publish(exchangeName, messages(i).getBytes))

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -76,7 +76,11 @@ object AmqpClientSpec extends DefaultRunnableSpec {
           .use { channel =>
             for {
               _      <- channel.queueDeclare(queueName)
-              _      <- channel.exchangeDeclare(exchangeName, ExchangeType.Custom("fanout")) // doesn't actually need to be a custom exchange type, just testing to make sure custom exchange types "work"
+              _      <-
+                channel.exchangeDeclare(
+                  exchangeName,
+                  ExchangeType.Custom("fanout")
+                ) // doesn't actually need to be a custom exchange type, just testing to make sure custom exchange types "work"
               _      <- channel.queueBind(queueName, exchangeName, RoutingKey("myroutingkey"))
               _      <-
                 ZIO.foreachParDiscard(0 until numMessages)(i => channel.publish(exchangeName, messages(i).getBytes))

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpClientSpec.scala
@@ -76,7 +76,7 @@ object AmqpClientSpec extends DefaultRunnableSpec {
           .use { channel =>
             for {
               _      <- channel.queueDeclare(queueName)
-              _      <- channel.exchangeDeclare(exchangeName, ExchangeType.Fanout)
+              _      <- channel.exchangeDeclare0(exchangeName, "fanout")
               _      <- channel.queueBind(queueName, exchangeName, RoutingKey("myroutingkey"))
               _      <-
                 ZIO.foreachParDiscard(0 until numMessages)(i => channel.publish(exchangeName, messages(i).getBytes))


### PR DESCRIPTION
In order to use [this plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange), we need the ability to declare an exchange with a non-sealed type. This PR simply exposes the java rabbitmq client library's `exchangeDeclare` method.