### PR TITLE
Updated dependencies.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=3.5.9
+version=3.7.3
 runner.dialect = scala213
 maxColumn = 120
 align.preset = most

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-lazy val mainScala2_13 = "2.13.8"
-lazy val scala2_12     = "2.12.16"
-lazy val scala3        = "3.2.0"
+lazy val mainScala2_13 = "2.13.10"
+lazy val scala2_12     = "2.12.17"
+lazy val scala3        = "3.2.2"
 
 lazy val `zio-amqp` = (project in file("."))
   .settings(name := "zio-amqp")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,15 +2,16 @@ import sbt._
 
 object Dependencies {
 
-  val zioVersion = "2.0.2"
+  val zioVersion = "2.0.13"
   lazy val deps  = Seq(
+    "dev.zio"                %% "zio"                         % zioVersion,
     "dev.zio"                %% "zio-streams"                 % zioVersion,
+    "dev.zio"                %% "zio-interop-reactivestreams" % "2.0.1",
+    "com.rabbitmq"            % "amqp-client"                 % "5.16.0",
+    "org.scala-lang.modules" %% "scala-collection-compat"     % "2.8.1",
+    "dev.zio"                %% "zio-prelude"                 % "1.0.0-RC18",
     "dev.zio"                %% "zio-test"                    % zioVersion % Test,
     "dev.zio"                %% "zio-test-sbt"                % zioVersion % Test,
-    "dev.zio"                %% "zio-interop-reactivestreams" % "2.0.0",
-    "com.rabbitmq"            % "amqp-client"                 % "5.16.0",
-    "ch.qos.logback"          % "logback-classic"             % "1.2.11"   % Test,
-    "org.scala-lang.modules" %% "scala-collection-compat"     % "2.8.1",
-    "dev.zio"                %% "zio-prelude"                 % "1.0.0-RC15"
+    "ch.qos.logback"          % "logback-classic"             % "1.4.6"    % Test
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.2


### PR DESCRIPTION
I'm using this library with Scala 2.13.10 and ZIO 2.0.13 and I get the following error when compiling:
```
[error] Symbol 'type zio.prelude.Newtype.Type' is missing from the classpath.
[error] This symbol is required by 'type nl.vroste.zio.amqp.model.ExchangeName'.
[error] Make sure that type Type is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'package.class' was compiled against an incompatible version of zio.prelude.Newtype.
[error]       _ <- channel.exchangeDeclare(
[error]            ^
```
Updating the dependency versions of `zio` and `zio-prelude` resolved my issue.
I also went ahead and updated other dependencies for the sake of completeness.
